### PR TITLE
Upgrade to Elm 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,8 +13,8 @@
         "ScatterPlot"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.3 <= v < 5.0.0",
-        "elm-lang/svg": "1.1.1 <= v < 2.0.0"
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/svg": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
Hi, just wanted to use the library with Elm 0.18.  This change excludes 0.17, which may not be desired or needed (I'm new to Elm).